### PR TITLE
Add delimeter to cron, api and return matched text in search query

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const { extractBlogUrl } = require('./controllers/extract-url');
 
 const cron = require('node-cron');
 const updateRecordsForDistinctCountries = require('./controllers/updateRecordWithIso3')
-const updateNullBlogs = require('./controllers/updateBlog')
+const updateDbRecord = require('./controllers/updateBlog')
 const updateMissingUrl = require('./controllers/updateMissingCountries')
 const updateDocument = require('./controllers/updateDocumentRecord')
 
@@ -62,7 +62,13 @@ app.get('/version', (req, res) => {
 
 
 app.post('/initialize', verifyToken, (req, res) => {
-  extractBlogUrl()
+  const { startIndex, delimeter } = req.body
+  if(typeof startIndex === 'number' 
+    && typeof delimeter === 'number'
+    && startIndex < delimeter){
+    extractBlogUrl({ startIndex, delimeter })
+  } else extractBlogUrl()
+  
   res.send('The blog extract as started!')
 })
 
@@ -72,11 +78,15 @@ app.post('/update-iso3-codes', verifyToken, (req, res) =>{
   res.send('ISO3 code update of all records started!')
 })
 
-app.post('/update-null-blogs', verifyToken, (req, res)=>{
-  console.log('update-null-blogs')
-  updateNullBlogs()
+app.post('/update-record', verifyToken, (req, res)=>{
+  const { startIndex, delimeter } = req.body
+  if(typeof startIndex === 'number' 
+    && typeof delimeter === 'number'
+    && startIndex < delimeter){
+      updateDbRecord({ startIndex, delimeter })
+  } else updateDbRecord()
 
-  res.send('Updates to blogs with null records started!')
+  res.send('Updates to articles records has started!')
 })
 
 app.post('/update-missing-countries', verifyToken, (req, res)=>{
@@ -103,12 +113,33 @@ app.use((err, req, res, next) => {
   res.status(500).send('Something broke!');
 })
 
-//RUN A CRON JOB 12AM EVERY SUNDAY TO EXECUTE THE SCRAPPER
-cron.schedule('0 0 * * 0', () => {
-  // Execute web extract function using child_process
-  extractBlogUrl()
+//TO AVOID AZURE WEB SERVICE MEMORY ISSUE,
+//THE CRON JOB WILL BE SPLIT WITH THE WEEKEND DAYS
+// FROM FRIDAY 7PM EVENING TO 11PM SUNDAY
+
+//THERE ARE IN TOTAL 183 COUNTRY/LANGUAGE PAGE INSTANCES ON THE UNDP WEBSITES
+//THE CRON JOBS WILL RUN 7 TIMES OVER THE WEEKEND TO ENSURE THAT EVERY PAGE IS CHECKED
+
+// Calculate the start index and delimeter for each run
+const calculateStartIndexAnddelimeter = (runNumber) => {
+  const startIndex = (runNumber - 1) * 26;
+  const delimeter = startIndex + 25;
+  return { startIndex, delimeter };
+};
+
+//RUN EVERY 7 HOURS
+cron.schedule('0 */7 * * 5-0', () => {
+  const currentHour = new Date().getHours();
+  const runNumber = Math.ceil((currentHour - 19) / 7);
+  //SET delimeter AND START INDEX FOR THE LAST RUN TO MAKE 183
+  const { startIndex, delimeter } = (runNumber === 7)
+  ? { startIndex: 156, delimeter: 183 }
+  : calculateStartIndexAnddelimeter(runNumber);
+
+  extractBlogUrl({ startIndex, delimeter });
 });
-  
+
+
 app.listen(port, () => {
   console.log(`app listening on port ${port}`)
   getVersionString().then(vo => {

--- a/controllers/extract-url.js
+++ b/controllers/extract-url.js
@@ -115,48 +115,46 @@ const searchForKeywords = async (url ) => {
   return;
 }
 
-const extractBlogUrl = async () => {
-  // Navigate to the base website
+const extractBlogUrl = async (params) => {
+  const { startIndex, delimeter, } = params || {};
+
   await driver.get(config['baseUrl']);
-  //  Click the "icon-globe" button to reveal the dropdown
   const globeButton = await driver.findElement(By.className(config['search.element.homepage.classname']));
   await globeButton.click();
-   // Find all the "countries" elements
   const countries = await driver.findElements(By.className(config['country_list.elements.homepage.classname']));
   let validUrls = [];
-  //  Loop through each "country" element
+
   for (let i = 0; i < countries.length; i++) {
     const country = countries[i];
-     // Extract the country name
-    const countryName = await country.findElement(By.className(config['country_name.element.homepage.classname'])).getText();
-     // Extract the URLs for each language in the "languages" element
     const languages = await country.findElements(By.className(config['language_list.elements.homepage.classname']));
+
     for (let j = 0; j < languages.length; j++) {
       const language = languages[j];
-       // Extract the URLs from the <a> elements
       const urls = await language.findElements(By.tagName(config['language_name.element.homepage.tagname']));
-       for (let k = 0; k < urls.length; k++) {
+      for (let k = 0; k < urls.length; k++) {
         const url = await urls[k].getAttribute(config['page_url.element.homepage.attribute']);
         validUrls.push(url);
       }
-     }
-    //  Loop through each URL and perform a search
-    for (let k = 0; k < validUrls.length; k++) {
+    }
+
+    //THIS IS A LONG LOOP, HENCE SEVER USUSALLY RUN OUT OF MEMORY
+    //SET START INDEX & delimeter TO LIMIT THE RANGE OF A SINGLE RUN
+    //SETTING SMALL delimeter SHOULD AVOID SERVER CRASHING AFTER RUNNING FOR A LONG TIME
+    const start= startIndex ?? 0;
+    const end = delimeter ?? validUrls.length
+    for (let k = start; k < end; k++) {
       const url = validUrls[k];
       // Logging needed for debugging
-      console.log('This is running for', k + 1, 'out of', validUrls.length);
-     
+      console.log('This is running for', k + 1, 'out of ', end);
       await searchForKeywords(url);
     }
-     // Logging needed for debugging
-    console.log('Successfully saved all blogs');
-     // Update iso3 code of all records
+
     updateRecordsForDistinctCountries();
   }
-   // Quit the WebDriver
+
   await driver.quit();
 }
-// extractBlogUrl()
+
 module.exports = {
   extractBlogUrl,
   searchForKeywords

--- a/controllers/saveToDb.js
+++ b/controllers/saveToDb.js
@@ -267,14 +267,14 @@ const extractAndSaveData = async (url, id = null, countryName = null ) => {
  
      try{
       country = await driver.findElement(By.css(config["country_name.element.blog.css_selector"])).getText() || null;
-    }catch(err){ country = ""}
+    }catch(err){ country = null}
  
     try{
       archorTags = await driver.findElements(By.css('a'));
      }
      catch (err){  archorTags = [] }
  
-     content = '';
+     content = null;
 
      //extract href link and text in a blog if it exist
      for (let i = 0; i < archorTags?.length; i++) {

--- a/controllers/updateBlog.js
+++ b/controllers/updateBlog.js
@@ -1,25 +1,32 @@
 require('dotenv').config();
 
 const DB = require('../db/index').DB
-const { getAllBlogsWithNull, getAllDocument } = require('./query');
+const { getAllDocument } = require('./query');
 const extractAndSaveData = require('./saveToDb');
 
-const updateNullBlogs = async () => {
+const updateDbRecord = async (params) => {
+  const { startIndex, delimeter, } = params || {};
+
   const res = await DB.blog.any(getAllDocument).catch((err)=>  [])
 
+  //THIS IS A LONG LOOP, HENCE SEVER USUSALLY RUN OUT OF MEMORY
+  //SET START INDEX & delimeter TO LIMIT THE RANGE OF A SINGLE RUN
+  //SETTING SMALL delimeter SHOULD AVOID SERVER CRASHING AFTER RUNNING FOR A LONG TIME
+  const start= startIndex ?? 0;
+  const end = delimeter ?? res.length
   // Loop through each URL and perform a search
-  for (let k = 0; k < res.length; k++) {
+  for (let k = start; k < end; k++) {
     //Log needed for debugging purposes
-    console.log('Updating content ', k+1 , ' of ', res.length, " records.")
+    console.log('Updating content ', k, ' of ', end, " records.")
 
     let dbUrl = res[k]['url'];
     let id = res[k]['id'];
 
-    await extractAndSaveData(dbUrl, id);
+    if(dbUrl && id) await extractAndSaveData(dbUrl, id);
   }
 
 //Log needed for debugging purposes
   console.log('Successfully updated all blogs')
 }
 
-module.exports = updateNullBlogs;
+module.exports = updateDbRecord;

--- a/middleware/search.js
+++ b/middleware/search.js
@@ -3,7 +3,7 @@ let findOR = /\sOR\s|\s?\,\s?/dgi
 let findPhrase = /(?<=(^|\s))\"[\w\d\*\s\']+\"(?=(\s|$))/dgi
 const fNest = /[\(\)\"\w\d\*\']+(\sor)?\s\(+[\"\w\d\*\s\'\(]+\)+/dgi
 
-function prepStr (_str) {
+function prepStr (_str = '') {
 	const max = ([..._str.matchAll(findPhrase)]?.length ?? 0) - 1
 
 	function findPhrases (_i = 0) {

--- a/searchTerm.js
+++ b/searchTerm.js
@@ -1,6 +1,6 @@
 const searchTerms = {
     en : [
-        "accelerator lab", "innovation-acclab", "acclab", "acceleratorlab", "AccLabGM", "innovation",
+        "accelerator lab", "innovation-acclab", "acclab", "acceleratorlab", "AccLabGM",
         ],
     fr: [
         "laboratoire d'acceleration", "accelerateur lab", "laboratoire d'accelerateur", "laboratoires d'acceleration", "laboratoires d'accelerateur",


### PR DESCRIPTION
- [x] Remove `innovation` from search terms.
- [x] Refine the search query to return matched text during a search. When a user searches for articles using a single word or with logical operators, it will return a data point `matched_texts` of the texts that match the search. The refined query also ensures word(s) match for any search.
- [x] Add a limit range for scrapping. The blog crapper has crashed many times while running because Azure runs out of memory. The addition of a limit range for the CRON jobs or API call for the scrapper initialization and update will allow users to specify within which range runs/update is desired. This will allow users to demistify the runs into batches.